### PR TITLE
make RCS work again when using aimbot again

### DIFF
--- a/csgo/shared/features.cpp
+++ b/csgo/shared/features.cpp
@@ -265,9 +265,9 @@ static void features::standalone_rcs(C_Player local_player)
 		int final_angle_x = (int)((( -new_punch.y * 2.0f) / sensitivity) / -0.022f);
 		int final_angle_y = (int)((( -new_punch.x * 2.0f) / sensitivity) / 0.022f);
 
-		if (!m_aimbot_active)
-			input::mouse_move(final_angle_x, final_angle_y);
-		// cs::input::mouse_move(final_angle_x, final_angle_y);
+		/*if (!m_aimbot_active)
+			input::mouse_move(final_angle_x, final_angle_y);*/
+		cs::input::mouse_move(final_angle_x, final_angle_y);
 	}
 	m_rcs_old_punch = current_punch;
 }


### PR DESCRIPTION
no clue why this was ever changed, maybe 

`if (m_aimbot_active)`  to make it rcs only activate when actually pressing the aimbot key?
