### PR TITLE
Adding BSpottedByMask Visible Check

### DIFF
--- a/cs2/shared/cs.h
+++ b/cs2/shared/cs.h
@@ -120,6 +120,7 @@ namespace cs
 		WEAPON_CLASS get_weapon_class(QWORD player);
 		QWORD get_node(QWORD player);
 		BOOL  is_valid(QWORD player, QWORD node);
+		BOOL  is_visible(QWORD player, int local_player_index);
 	}
 
 	namespace node


### PR DESCRIPTION
@ekknod How can i get the `m_entitySpottedState ` offset in this system? Because there is more than one offset with the same name.

`C_PlantedC4 -> m_entitySpottedState 0xe90`
`C_C4 -> m_entitySpottedState 0x1a38`
`C_CSPlayerPawnBase -> 0x1630 `